### PR TITLE
Mostrar tag ao invés de username

### DIFF
--- a/src/commands/slash/info/user.js
+++ b/src/commands/slash/info/user.js
@@ -87,9 +87,9 @@ module.exports = {
                     .setColor("RANDOM")
                     .setTimestamp()
                     .setThumbnail(member.user.displayAvatarURL({dynamic: true, format: "png", size: 1024}))
-                    .setTitle("🎯 Informações para " + member.user.username)
+                    .setTitle("🎯 Informações para " + member.user.tag)
                     .addFields(
-                        {name: "📋 Nome de Usuário", value: "`" + member.user.username + "`", inline: true},
+                        {name: "📋 Nome de Usuário", value: "`" + member.user.tag + "`", inline: true},
                         {name: "🎫 Nickname", value: "`" + (member.member.nickname !== null ? member.member.nickname : "Sem Apelido" ) + "`", inline: true},
                         {name: "💮 Discriminador", value: "`" + member.user.discriminator + "`", inline: true},
                         {name: "📌 Id de Usuário", value: "`" + member.user.id + "`", inline: true},


### PR DESCRIPTION
Conforme sugerido pelo @gabrielkinash1, o comando `user/info` poderia retornar a tag, no formato `nick#0000`, ao invés de apenas o nickname.

Notei que existem algumas duplicações de código que dificultam espalhar essa mudança pra todos os comandos. Uns 20 ou 30 arquivos seriam afetados.

Vou abrir uma issue pra ver o que podemos fazer para centralizar isso e facilitar nossa vida nas manutenções 😁